### PR TITLE
fix: mask-composite:xor not working in Firefox

### DIFF
--- a/components/views/overview-build-in-public.vue
+++ b/components/views/overview-build-in-public.vue
@@ -151,6 +151,7 @@ const featureGroups = [
       background: radial-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.05))
       -webkit-mask: linear-gradient(black, black) content-box content-box, linear-gradient(black, black)
       -webkit-mask-composite: xor
+      -webkit-mask-composite: subtract
 
   .features-part
     position: relative
@@ -459,4 +460,5 @@ const featureGroups = [
     background: radial-gradient(60px circle, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.1))
     -webkit-mask: linear-gradient(black, black) content-box content-box, linear-gradient(black, black)
     -webkit-mask-composite: xor
+    mask-composite: subtract
 </style>

--- a/components/views/overview-plan.vue
+++ b/components/views/overview-plan.vue
@@ -136,6 +136,7 @@ onMounted(() => {
           background: linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0))
           -webkit-mask: linear-gradient(black, black) content-box content-box, linear-gradient(black, black)
           -webkit-mask-composite: xor
+          mask-composite: exclude
 
         &:hover
           --border-color: rgba(255, 255, 255, 0.2)

--- a/components/views/user-story-card.vue
+++ b/components/views/user-story-card.vue
@@ -52,6 +52,7 @@ onMounted(() => {
     background: radial-gradient(420px circle at var(--x) var(--y), rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.1))
     -webkit-mask: linear-gradient(black, black) content-box content-box, linear-gradient(black, black)
     -webkit-mask-composite: xor
+    mask-composite: exclude
 
   .story-content
     font-weight: 500

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -287,6 +287,7 @@ await loadData()
         background: linear-gradient(rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.1) 100%)
         -webkit-mask: linear-gradient(black, black) content-box content-box, linear-gradient(black, black)
         -webkit-mask-composite: xor
+        mask-composite: exclude
 
       &:not(.is-current):hover
         background: linear-gradient(180deg, rgba(217, 217, 217, 0.20) 0%, rgba(255, 255, 255, 0.19) 14.06%, rgba(217, 217, 217, 0.10) 100%);


### PR DESCRIPTION
Fix `-webkit-mask-composite: xor` not working in Firefox.

![CleanShot 2023-07-19 at 19 20 13@2x](https://github.com/toeverything/AFFiNE.pro/assets/39363750/e051d18d-14dc-4f92-88da-daea3712cf60)

- release button
  ![CleanShot 2023-07-19 at 19 20 58@2x](https://github.com/toeverything/AFFiNE.pro/assets/39363750/b752ebe2-5f19-4027-b8d0-e44479496d37)
- story cards
   ![CleanShot 2023-07-19 at 19 22 10@2x](https://github.com/toeverything/AFFiNE.pro/assets/39363750/3d6af823-ce7f-4493-91a2-da4a310dcde6)
- overview build in public
   ![CleanShot 2023-07-19 at 19 22 52@2x](https://github.com/toeverything/AFFiNE.pro/assets/39363750/7847eec5-ec1e-4d6f-be04-33c6a7874823)
   ![CleanShot 2023-07-19 at 19 24 39@2x](https://github.com/toeverything/AFFiNE.pro/assets/39363750/f53bc948-f263-4aba-b3f8-1b8e71f40308)



