### PR TITLE
fix(overview-user-stories): fix the spotlight doesn't move on page scroll

### DIFF
--- a/components/views/overview-user-stories.vue
+++ b/components/views/overview-user-stories.vue
@@ -14,9 +14,9 @@
 </template>
 
 <script setup lang="ts">
-import { useScroll, useMouseInElement } from "@vueuse/core"
+import { useElementBounding, useMouse } from "@vueuse/core"
 
-const clamp = (num, min, max) => Math.min(Math.max(num, min), max)
+const clamp = (num: number, min: number, max: number) => Math.min(Math.max(num, min), max)
 
 const stories: UserStory[] = [
   { avatar: '/user-stories/Frame 5.png', name: 'PanicN3xus', position: 'User', content: `AFFiNE is an exceptional project that elevates note-making to a whole new level. I am highly impressed by the number of features that it brings to the table. Having tried several other open-source note-making software, I can confidently say that AFFiNE is the best.` },
@@ -29,20 +29,15 @@ const stories: UserStory[] = [
   { avatar: '/user-stories/Frame 2.png', name: 'Eliot', position: 'Student', content: `AFFiNE is an open source that is close to its community and filled with useful features. I use edgeless mode to connect all my knowledge to a single page.` },
 ]
 
-const el = ref<HTMLDivElement>(null)
-const scrollState = reactive({
-  y: 0
-})
+const el = ref<HTMLDivElement>()
 
-const { elementX, elementY } = useMouseInElement(el)
+const { left, top } = useElementBounding(el)
+const { x, y } = useMouse({ type: "client" })
+
+const elementX = computed(() => x.value - left.value)
+const elementY = computed(() => y.value - top.value)
 const clampedX = computed(() => clamp(elementX.value, -300, 1500))
 const clampedY = computed(() => clamp(elementY.value, -100, 1000))
-
-onMounted(async () => {
-  await nextTick()
-  elementX.value = 500
-  elementY.value = 200
-})
 
 </script>
 


### PR DESCRIPTION
### description

I found that the previous implementation using `useMouseInElement` is not working due to `vueuse`'s internal bug ([this issue](https://github.com/vueuse/vueuse/issues/2922)).

Instead of using `useMouseInElement` directly, we can use `useElementBounding` and `useMouse` together.

By the way, I've removed some code that is unnecessary in this file. If there's something I haven't considered, please point it out or close this pr. 

:)

### compare

- before

https://github.com/toeverything/AFFiNE.pro/assets/39363750/0a58c400-86eb-43f7-ad7b-5f9e5e306ffd


- after

https://github.com/toeverything/AFFiNE.pro/assets/39363750/151b87d0-045e-4fc2-8e9f-4cebac52396f


