### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/modules/mixpanel/runtime/composables.ts
+++ b/modules/mixpanel/runtime/composables.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export function useMixpanel() {
   return useNuxtApp().$mixpanel

--- a/modules/mixpanel/runtime/plugin.ts
+++ b/modules/mixpanel/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 import mixpanel from 'mixpanel-browser'
 
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.