### PR TITLE
fix: mobile drowdown menu collapse transition

### DIFF
--- a/components/widgets/header-navbar-mobile.vue
+++ b/components/widgets/header-navbar-mobile.vue
@@ -15,8 +15,8 @@
         )
           nuxt-icon.icon-menu( :name="isOpen ? 'menu-close' : 'hamburg-menu'" )
 
-    el-collapse-transition
-      .collapsed-menu( v-show="isOpen" )
+    div
+      .collapsed-menu( :style="{ maxHeight: isOpen ? 'var(--h)' : '0px' }" )
         .menu-list
           //- .nav-item
           //-   nuxt-link( to="/" ) {{ $t('home') }}
@@ -49,26 +49,23 @@
 
 <script setup lang="ts">
 import { onClickOutside } from '@vueuse/core'
-import { PATH, CONFIG } from '~/utils/constants'
-const { locale, locales, localeProperties, setLocaleCookie } = useI18n()
-
-const props = defineProps<{
-  y: number
-}>()
+const { locale, setLocaleCookie } = useI18n()
 
 const menuHandler = ref(null)
 const ignoreElRef = ref(null)
 const isOpen = ref(false)
-const isOpenLangList = ref(false)
 
-onClickOutside(menuHandler, (event) => {
-  isOpen.value = false
-}, { ignore: [ ignoreElRef ] })
+onClickOutside(
+  menuHandler,
+  (event) => {
+    isOpen.value = false
+  },
+  { ignore: [ignoreElRef] },
+)
 
 watch(locale, () => {
   setLocaleCookie(locale.value)
 })
-
 </script>
 
 <style lang="stylus">
@@ -111,12 +108,15 @@ watch(locale, () => {
       border-bottom-color: rgba(0, 0, 0, 0.10);
 
     .collapsed-menu
+      transition: max-height 0.3s ease-in-out
       // background: var(--secondary)
       overflow-y: scroll
-      height: s('calc(100dvh - var(--navbar-height))')
+      --h: s('calc(100dvh - var(--navbar-height))')
+      height: var(--h)
 
       .menu-list
         padding: 0 32px
+        height: 100%
 
         .nav-item
           font-weight: 500;


### PR DESCRIPTION
Current:


https://github.com/toeverything/AFFiNE.pro/assets/41265413/319d4d39-0cbf-4fe6-987f-662ef27f1063


Fixed:
https://github.com/toeverything/AFFiNE.pro/assets/41265413/02a419c0-85f4-4842-8439-8a5612632815


This is an element plus transition bug, location code at 
![152871699598291_ pic](https://github.com/toeverything/AFFiNE.pro/assets/41265413/7045d741-1342-47c4-9917-50871a61280e)

It not get the element height property if it exists, instead of `scrollHeight`
